### PR TITLE
Specify httpretty

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps=
     pytest-pep8
     pytest-cov
     pytest-flakes
-    httpretty==0.8.8
+    httpretty==0.8.6
 
 [testenv:py27]
 deps=

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps=
     pytest-pep8
     pytest-cov
     pytest-flakes
-    httpretty
+    httpretty==0.8.8
 
 [testenv:py27]
 deps=


### PR DESCRIPTION
httpretty has not yet resolved the inifinite loop in 0.8.8.
So pinning 0.8.6.